### PR TITLE
Definitions use processed token

### DIFF
--- a/src/client/api/ApiClient.ts
+++ b/src/client/api/ApiClient.ts
@@ -13,6 +13,7 @@ export type DefinitionDTO = {
 
 export type WordDTO = {
   token: string;
+  processedToken: string;
   tag: string;
   lemma: string;
   definitions: Array<DefinitionDTO>;

--- a/src/components/Reader/Reader.tsx
+++ b/src/components/Reader/Reader.tsx
@@ -34,7 +34,7 @@ export const Reader = () => {
   // Look up definitions for the words if submitted
   useEffect(() => {
     if (words.length > 0) {
-      const tokens = words.map((word) => word.token);
+      const tokens = words.map((word) => word.processedToken);
       client.getDefinitions(language, tokens).then((results) => {
         // This mutates the object anyway, but we want to trigger a re-rendering.
         setDefinitions(new DefinitionsStore(results));


### PR DESCRIPTION
Tokens used for dictionary lookup aren't necessarily what the user typed in. We do processing in the backend to make them more suited for lookup. Let's use that processing.